### PR TITLE
BPManager Protocol minor refactor

### DIFF
--- a/Bellerophon/Bellerophon/Sources/BPManager.swift
+++ b/Bellerophon/Bellerophon/Sources/BPManager.swift
@@ -98,7 +98,7 @@ public class BellerophonManager: NSObject {
 
     // MARK: Force Update Methods
     func performForceUpdate() {
-        self.delegate?.checkVersion(self)
+        self.delegate?.shouldForceUpdate()
     }
 
     // MARK: Kill Switch Methods

--- a/Bellerophon/Bellerophon/Sources/BPManagerProtocol.swift
+++ b/Bellerophon/Bellerophon/Sources/BPManagerProtocol.swift
@@ -19,11 +19,9 @@ import Foundation
     func bellerophonStatus(manager: BellerophonManager, completion: (status: BellerophonStatusProtocol?, error: NSError?) -> ())
 
     /**
-    The force update is active, the app should check the app's version and force to update if needed. An alert should be displayed to redirect to the App Store.
-
-    - parameter manager: The Bellerophon manager.
+    The app is notified that a force update should occur. An alert should be displayed to redirect to the App Store.
     */
-    func checkVersion(manager: BellerophonManager)
+    func shouldForceUpdate()
 
     optional
     /**

--- a/Example/Bellerophon/AppDelegate.swift
+++ b/Example/Bellerophon/AppDelegate.swift
@@ -55,8 +55,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BellerophonManagerProtoco
         }
     }
 
-    func checkVersion(manager: BellerophonManager) {
-        // CHECK APP VERSION
+    func shouldForceUpdate() {
+        let alert = UIAlertView(title: "Force Update", message: "Force update message is received!", delegate: self, cancelButtonTitle: "Got it")
+        alert.show()
     }
 
 }


### PR DESCRIPTION
Renamed methods that actually are called after confirmation of force update when they had acted as before confirmation
@ThibaultKlein 