### PR TITLE
keyWindow bug fix

### DIFF
--- a/Bellerophon/Bellerophon/Sources/BPManager.swift
+++ b/Bellerophon/Bellerophon/Sources/BPManager.swift
@@ -125,7 +125,10 @@ public class BellerophonManager: NSObject {
     internal func dismissKillSwitchIfNeeded() {
         if killSwitchWindow.keyWindow {
             delegate?.bellerophonWillDisengage?(self)
-            killSwitchWindow.hidden = true;
+            if let mainWindow = UIApplication.sharedApplication().delegate?.window {
+                mainWindow?.makeKeyAndVisible()
+            }
+            killSwitchWindow.hidden = true
         }
     }
 


### PR DESCRIPTION
Fixed a bug where killSwitchView would not be displayed again if it had displayed before. 

The problem here is that once the `killSwitchView` is displayed, the `killSwitchWindow` will be the keyWindow. When `killSwitchView` gets dismissed, the keyWindow is not returned to the main window in the application. So next time the `killSwitchView` is going to be displayed, in `displayKillSwitch()`, the if statement `if !killSwitchWindow.keyWindow` will always fail because the killSwitchWindow is already the keyWindow