### PR TITLE
Adding support for Swift 4 and resolving @objc compiler errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # # * https://github.com/supermarin/xcpretty#usage
 #
 language: objective-c
-osx_image: xcode8
+osx_image: xcode9
 cache: cocoapods
 podfile: Example/Podfile
 before_install:

--- a/Bellerophon/Bellerophon.xcodeproj/project.pbxproj
+++ b/Bellerophon/Bellerophon.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -339,6 +340,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -362,7 +364,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.prolificinteractive.Bellerophon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -383,7 +384,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -397,7 +397,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.prolificinteractive.BellerophonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -412,7 +411,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.prolificinteractive.BellerophonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Bellerophon/Bellerophon/Sources/BPManager.swift
+++ b/Bellerophon/Bellerophon/Sources/BPManager.swift
@@ -61,7 +61,7 @@ public class BellerophonManager: NSObject {
     /**
      Retrieves and handles the app status from the AMS endpoint
      */
-    public func checkAppStatus() {
+    @objc public func checkAppStatus() {
         assert(killSwitchView != nil, "The kill switch view has to be defined.")
 
         guard !requestPending else {
@@ -119,7 +119,7 @@ public class BellerophonManager: NSObject {
         }
     }
 
-    internal func stopTimer() {
+    @objc internal func stopTimer() {
         retryTimer?.invalidate()
         retryTimer = nil
     }


### PR DESCRIPTION
This PR sets the 'Swift_Version' build setting to 4.0, and subsequently resolves the two open compiler warnings that are caused.

See Issue #19 for more information