### PR TITLE
[FEATURE] Allow Force Update to show View

### DIFF
--- a/Bellerophon/Bellerophon/Sources/BPManagerDelegate.swift
+++ b/Bellerophon/Bellerophon/Sources/BPManagerDelegate.swift
@@ -34,8 +34,9 @@
      Indicates that Bellerophon is about to appear on the screen.
 
      - parameter manager: The Bellerophon manager.
+     - parameter enableForceUpdate: Boolean to determine if force update should be shown
      */
-    func bellerophonWillEngage(_ manager: BellerophonManager)
+    func bellerophonWillEngage(_ manager: BellerophonManager, enableForceUpdate: Bool)
 
     @objc optional
     /**
@@ -44,5 +45,6 @@
      - parameter manager: The Bellerophon manager.
      */
     func bellerophonWillDisengage(_ manager: BellerophonManager)
-    
+
 }
+

--- a/Bellerophon/BellerophonTests/MockBPManager.swift
+++ b/Bellerophon/BellerophonTests/MockBPManager.swift
@@ -15,7 +15,7 @@ class MockBPManager: BellerophonManager {
     var startAutoCheckingIsCalled: Bool!
     var dismissKillSwitchIfNeededIsCalled: Bool!
     
-    override func displayKillSwitch() {
+    override func displayKillSwitch(enableForceUpdate: Bool) {
         displayKillSwitchIsCalled = true
     }
     

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ func shouldForceUpdate() {
 
 Your app is not ready to work with Bellerophon. If the status tells Bellerophon to kill the app, it will display a full screen view on top of everything and will keep it like that until the status API indicates that the app should work again. A timer is also starting based on the retry interval provided by the status object.
 
+Similarily, `BellerophonManager` on init provides a `shouldPresentViewForForceUpdate` parameter that, if enabled, will display a full screen view as well instead of triggering `shouldForceUpdate`.
+
 Your API and model should be able to indicate at least these informations :
 
 * Is the API active or inactive?


### PR DESCRIPTION
- Currently, Bellerophon only takes over the screen for kill switch, not force update. This PR addresses this concern.
- Allow force update to take over window if developer requires